### PR TITLE
IG-20021: Implement caching.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,5 +60,5 @@ set-version:
 
 .PHONY: dist
 dist:
-    rm -rf dist build
+	rm -rf dist build
 	python -m build --sdist --wheel --outdir dist/ .

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,7 @@ Obj = namedtuple('Obj', 'path data')
 
 @pytest.fixture
 def fs():
-    fs = V3ioFS()
+    fs = V3ioFS(cache_validity_seconds=0)
     yield fs
     fs._client.close()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import uuid
 from collections import namedtuple
 from datetime import datetime
 from http import HTTPStatus
@@ -24,8 +24,7 @@ from v3iofs import V3ioFS
 from v3iofs.fs import _new_client
 
 test_container = 'bigdata'  # TODO: configure
-test_dir = 'v3io-fs-test'
-
+test_dir = f'v3io-fs-test-{uuid.uuid4().hex}'
 
 Obj = namedtuple('Obj', 'path data')
 

--- a/tests/test_dask.py
+++ b/tests/test_dask.py
@@ -11,10 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
 from datetime import datetime
 from pathlib import Path
+import uuid
 
 import dask.bag as db
 import dask.dataframe as dd
@@ -29,7 +28,6 @@ Beth,Lettuce,1.2,13
 Summer,M&M,2.2,7
 Morty,Twix,1.7,5
 '''
-
 
 tests_root = Path(__file__).absolute().parent
 test_pq = tests_root / 'sanchez.pq'

--- a/tests/test_dask.py
+++ b/tests/test_dask.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 from datetime import datetime
 from pathlib import Path
-import uuid
 
 import dask.bag as db
 import dask.dataframe as dd

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -14,7 +14,6 @@
 from datetime import datetime, timezone
 from os.path import basename, dirname
 from pathlib import Path
-import uuid
 
 import fsspec
 import pytest

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -109,7 +109,7 @@ def test_directory(fs, tree):
 
 def test_fsspec():
     fs = fsspec.filesystem("v3io")
-    dirpath = f'/{test_container}/{test_dir}/fss-{uuid.uuid4().hex}'
+    dirpath = f'/{test_container}/{test_dir}/fss'
     file_name = datetime.now().strftime('test_%f')
     filepath = f'{dirpath}/{file_name}.txt'
     with fs.open(filepath, 'wb') as fp:

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -11,10 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 from datetime import datetime, timezone
 from os.path import basename, dirname
 from pathlib import Path
+import uuid
 
 import fsspec
 import pytest
@@ -109,7 +109,7 @@ def test_directory(fs, tree):
 
 def test_fsspec():
     fs = fsspec.filesystem("v3io")
-    dirpath = f'/{test_container}/{test_dir}/fss'
+    dirpath = f'/{test_container}/{test_dir}/fss-{uuid.uuid4().hex}'
     file_name = datetime.now().strftime('test_%f')
     filepath = f'{dirpath}/{file_name}.txt'
     with fs.open(filepath, 'wb') as fp:
@@ -125,5 +125,4 @@ def test_fsspec():
     with fs.open(prefix + filepath) as fp:
         data = fp.read()
     assert data == b'123', 'unexpected data'
-    print(filepath)
     fs.rm(filepath)

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -14,7 +14,6 @@
 from datetime import datetime
 import pandas as pd
 from conftest import test_container, test_dir
-import uuid
 
 csv_data = b'''
 name,item,price,quantity

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -11,11 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
 from datetime import datetime
 import pandas as pd
 from conftest import test_container, test_dir
+import uuid
 
 csv_data = b'''
 name,item,price,quantity

--- a/v3iofs/fs.py
+++ b/v3iofs/fs.py
@@ -65,6 +65,8 @@ class _Cache:
             if key_time > until + self._cache_validity_seconds or len(self._cache) > self._capacity:
                 del self._cache[key]
                 num_removed += 1
+            else:
+                break
             self._time_to_key = self._time_to_key[num_removed:]
 
 


### PR DESCRIPTION
Implements caching for V3ioFS.info().

For a folder with 497 small parquet files, this change reduced the runtime from 60s to 42s (%30).