### PR TITLE
Use singleton `V3ioFS` in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,12 +28,15 @@ test_dir = f"v3io-fs-test-{uuid.uuid4().hex}"
 
 Obj = namedtuple("Obj", "path data")
 
+_v3io_fs_singleton = None
+
 
 @pytest.fixture
 def fs():
-    fs = V3ioFS()
-    yield fs
-    fs._client.close()
+    global _v3io_fs_singleton
+    if not _v3io_fs_singleton:
+        _v3io_fs_singleton = V3ioFS()
+    yield _v3io_fs_singleton
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,8 @@ test_dir = f"v3io-fs-test-{uuid.uuid4().hex}"
 
 Obj = namedtuple("Obj", "path data")
 
+# Use a singleton to avoid hang on fs._client.close()
+# This only happens in GitHub actions CI for an unknown reason
 _v3io_fs_singleton = None
 
 


### PR DESCRIPTION
To avoid hang on call to `fs._client.close()`.